### PR TITLE
Don't use rospy_message_converter from source

### DIFF
--- a/docker/mir_robot/Dockerfile
+++ b/docker/mir_robot/Dockerfile
@@ -763,7 +763,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN mkdir -p ${CATKIN_WS_SRC} \
   && cd ${CATKIN_WS_SRC} \
-  && git clone https://github.com/uos/rospy_message_converter.git \
   && git clone -b ${ROS_DISTRO}-hook https://github.com/brean/mir_robot.git
 
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh \


### PR DESCRIPTION
This is already installed as binaries. Cloning the source is not
required.