### PR TITLE
Patch apt sources and install different numpy version

### DIFF
--- a/docker/mobipick_labs/Dockerfile
+++ b/docker/mobipick_labs/Dockerfile
@@ -2,6 +2,19 @@ FROM brean/mobipick:noetic
 
 ENV CATKIN_WS=/root/catkin_ws
 ENV CATKIN_WS_SRC=${CATKIN_WS}/src
+ARG DEBIAN_FRONTEND=noninteractive
+
+# remove stale ROS list to allow apt to run, then add fresh keyring and source
+RUN set -eux; \
+    rm -f /etc/apt/sources.list.d/ros*.list || true; \
+    apt-get update -qq; \
+    apt-get install -y --no-install-recommends ca-certificates curl gnupg; \
+    curl -fsSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key \
+      | gpg --dearmor -o /usr/share/keyrings/ros-archive-keyring.gpg; \
+    echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros/ubuntu focal main' \
+      > /etc/apt/sources.list.d/ros1.list; \
+    apt-get update -qq; \
+    rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update -qq \
     && apt-get install -y --no-install-recommends \
@@ -9,6 +22,7 @@ RUN apt-get update -qq \
         espeak-data libespeak1 libportaudio2 libsonic0 \
         python3-pydot ros-noetic-qt-dotgraph \
         ros-noetic-rqt-graph \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # TODO: maybe not the best idea to run the default install-deps scripts,

--- a/docker/mobipick_labs/Dockerfile
+++ b/docker/mobipick_labs/Dockerfile
@@ -3,8 +3,13 @@ FROM brean/mobipick:noetic
 ENV CATKIN_WS=/root/catkin_ws
 ENV CATKIN_WS_SRC=${CATKIN_WS}/src
 ARG DEBIAN_FRONTEND=noninteractive
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+ENV PIP_NO_CACHE_DIR=1
 
-# remove stale ROS list to allow apt to run, then add fresh keyring and source
+# use bash for RUN so we can 'source' scripts
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# refresh ROS apt source and base tools
 RUN set -eux; \
     rm -f /etc/apt/sources.list.d/ros*.list || true; \
     apt-get update -qq; \
@@ -16,21 +21,30 @@ RUN set -eux; \
     apt-get update -qq; \
     rm -rf /var/lib/apt/lists/*
 
+# system packages
 RUN apt-get update -qq \
     && apt-get install -y --no-install-recommends \
-        python3-pip python3-pyassimp libespeak-dev \
+        git python3-pip python3-pyassimp libespeak-dev \
         espeak-data libespeak1 libportaudio2 libsonic0 \
         python3-pydot ros-noetic-qt-dotgraph \
         ros-noetic-rqt-graph \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# TODO: maybe not the best idea to run the default install-deps scripts,
-# it might already include some stuff already installed in the mobipick-image?!
-RUN cd ${CATKIN_WS_SRC} \
-  && git clone https://github.com/dfki-ni/mobipick_labs.git \
-  && . ${CATKIN_WS}/devel/setup.sh \
-  && cd mobipick_labs \
-  && ./install-deps.sh \
-  && ./build.sh \
-  && rm -rf /var/lib/apt/lists/*
+# pip compatible with py3.8 and pin scientific stack
+RUN python3 -m pip install --upgrade 'pip<25'
+RUN python3 -m pip install --upgrade --force-reinstall \
+      'numpy==1.24.4' 'scipy==1.10.1' 'ConfigSpace>=0.7.0'
+
+# fetch sources and build (source ROS with nounset disabled briefly)
+RUN set -eux; \
+  mkdir -p "${CATKIN_WS_SRC}"; \
+  cd "${CATKIN_WS_SRC}"; \
+  git clone https://github.com/dfki-ni/mobipick_labs.git; \
+  export ROS_MASTER_URI=${ROS_MASTER_URI:-http://localhost:11311}; \
+  export ROS_HOSTNAME=${ROS_HOSTNAME:-localhost}; \
+  export ROS_IP=${ROS_IP:-127.0.0.1}; \
+  set +u; source /opt/ros/noetic/setup.bash; set -u; \
+  cd mobipick_labs; \
+  ./install-deps.sh; \
+  ./build.sh


### PR DESCRIPTION
This PR fixes:
- authentication issues with ROS servers due to expired keys
- tables demo node crash issue